### PR TITLE
Mobile map in full screen

### DIFF
--- a/src/components/curr_item_dialog.vue
+++ b/src/components/curr_item_dialog.vue
@@ -4,6 +4,12 @@ import { computed, onMounted, ref, watch } from "vue";
 import { useDataStore } from "../stores/dataStore.ts";
 import { MAIN_CATEGORIES, SUB_CATEGORIES } from "../constants/categoryConfig";
 
+const props = withDefaults(defineProps<{
+  attachTarget?: string;
+}>(), {
+  attachTarget: '.datatable-wrapper',
+});
+
 const dataStore = useDataStore()
 
 const active = ref(true);
@@ -180,7 +186,7 @@ const sortedWochentage = dataStore.getSortedWochentageOptionen();
   <v-dialog 
     v-model="active" 
     class="dialog-container" 
-    :attach="'.datatable-wrapper'" 
+    :attach="props.attachTarget" 
     :contained="true" 
     :scrim="false"
     :persistent="true"

--- a/src/components/datamap.vue
+++ b/src/components/datamap.vue
@@ -227,6 +227,18 @@ watch(() => props.items, () => {
   updateMarkers();
 });
 
+watch(() => [props.isMapOpen, props.isMobile], async ([isMapOpen, isMobile]) => {
+  if (!map.value || !isMapOpen) return;
+
+  // Leaflet needs a resize signal after layout switches to fullscreen.
+  await nextTick();
+  map.value.invalidateSize();
+
+  if (isMobile) {
+    map.value.invalidateSize();
+  }
+});
+
 // Lebenszyklus-Hooks
 onMounted(() => {
   nextTick(() => {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import { ref, onMounted, onBeforeUnmount, computed } from 'vue';
+import { ref, onMounted, onBeforeUnmount, computed, watch } from 'vue';
 import Data_loader from "../components/data_loader.vue";
 import Filter_menu from "../components/filter_menu.vue";
 import Datatable from "../components/datatable.vue";
@@ -63,8 +63,18 @@ onMounted(() => {
   window.addEventListener('resize', dataStore.checkIfMobile);
 });
 
+watch([isMobile, isMapOpen], ([mobile, mapOpen]) => {
+  if (mobile && mapOpen) {
+    document.body.style.overflow = 'hidden';
+    return;
+  }
+
+  document.body.style.overflow = '';
+});
+
 onBeforeUnmount(() => {
   window.removeEventListener('resize', dataStore.checkIfMobile);
+  document.body.style.overflow = '';
 });
 
 </script>
@@ -91,17 +101,6 @@ onBeforeUnmount(() => {
               :items="dataStore.get_filtered_data()"
               @item-clicked="handleItemClick"
           />
-          
-          <!-- Overlay to capture clicks when dialog is open -->
-          <div 
-            v-if="dataStore.current_item !== null" 
-            class="dialog-backdrop"
-            @mousedown="onBackdropMouseDown"
-            @mouseup="onBackdropMouseUp"
-          ></div>
-          
-          <!--View when item selected - now only overlays datatable /-->
-          <Curr_item_dialog class="mt-5" v-if="dataStore.current_item !== null" />
         </div>
 
         <!-- Button zum Ein-/Ausklappen der Karte /-->
@@ -110,7 +109,8 @@ onBeforeUnmount(() => {
           class="toggle-map-button"
           :class="{
             'toggle-map-button--mobile': isMobile,
-            'toggle-map-button--open': isMapOpen
+            'toggle-map-button--open': isMapOpen,
+            'toggle-map-button--mobile-open': isMobile && isMapOpen
           }"
         >
           {{ isMapOpen ? (isMobile ? '▼ Karte ausblenden' : '◀ Karte ausblenden') : (isMobile ? '▲ Karte anzeigen' : 'Karte anzeigen ▶') }}
@@ -121,10 +121,29 @@ onBeforeUnmount(() => {
             v-show="isMapOpen"
             ref="datamap"
             class="datamap"
-            :class="{ 'datamap--mobile': isMobile }"
+            :class="{
+              'datamap--mobile': isMobile,
+              'datamap--mobile-open': isMobile && isMapOpen
+            }"
             :isMobile="isMobile"
             :isMapOpen="isMapOpen"
             :items="dataStore.get_filtered_data()"
+        />
+
+        <!-- Overlay to capture clicks when dialog is open -->
+        <div 
+          v-if="dataStore.current_item !== null"
+          class="dialog-backdrop"
+          :class="{ 'dialog-backdrop--fullscreen': isMobile && isMapOpen }"
+          @mousedown="onBackdropMouseDown"
+          @mouseup="onBackdropMouseUp"
+        ></div>
+
+        <!-- Item dialog is attached to content container so it also works above map fullscreen -->
+        <Curr_item_dialog
+          class="mt-5"
+          v-if="dataStore.current_item !== null"
+          attachTarget=".content-container"
         />
     </div>
   </div>
@@ -167,8 +186,13 @@ onBeforeUnmount(() => {
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 100;
+  z-index: 1250;
   cursor: pointer;
+}
+
+.dialog-backdrop--fullscreen {
+  position: fixed;
+  inset: 0;
 }
 
 .datamap {
@@ -248,11 +272,26 @@ onBeforeUnmount(() => {
   }
 
   .content-container.map-open.mobile .datatable-wrapper {
-    height: 100vh;
+    display: none;
   }
 
-  .content-container.map-open.mobile .datamap {
-    height: 100vh;
+  .datamap--mobile-open {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100dvh;
+    z-index: 1200;
+    background: white;
+  }
+
+  .toggle-map-button--mobile-open {
+    position: fixed;
+    left: 50%;
+    right: auto;
+    bottom: max(12px, env(safe-area-inset-bottom));
+    transform: translateX(-50%);
+    margin: 0;
+    z-index: 1300;
   }
 
   .toggle-map-button--open {


### PR DESCRIPTION
löst #73

Folgende Änderungen:
- Die Map ist jetzt in der mobilen Variante Fullscreen.
- Entsprechend wird das Scrollverhalten so geändert, dass die Map gescrollt wird und nicht die Seite.
- Die Anzeige von Einträgen wird von der Liste entkoppelt, damit sie auch über der Map geschehen kann.